### PR TITLE
Support notifications and the tray icon

### DIFF
--- a/com.governikus.ausweisapp2.yaml
+++ b/com.governikus.ausweisapp2.yaml
@@ -8,7 +8,9 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --socket=pcsc
-modules: 
+  - --own-name=org.kde.* # Workaround for org.kde.StatusNotifierWatcher support, see https://github.com/flathub/com.viber.Viber/issues/4
+  - --talk-name=org.freedesktop.Notifications
+modules:
   - name: pcsc-lite
     sources:
       - type: archive


### PR DESCRIPTION
I've tested it on GNOME with https://extensions.gnome.org/extension/615/appindicator-support/